### PR TITLE
Dummy and migration refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "A query builder using rust concepts."
 categories = ["database"]
 repository = "https://github.com/LHolten/rust-query/"
 license = "MIT OR Apache-2.0"
+rust-version = "1.84"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/blog.rs
+++ b/examples/blog.rs
@@ -12,17 +12,6 @@ enum Schema {
         #[version(1..)]
         email: String,
     },
-    Story {
-        author: User,
-        title: String,
-        content: String,
-    },
-    #[unique(user, story)]
-    Rating {
-        user: User,
-        story: Story,
-        stars: i64,
-    },
 }
 use v0::*;
 

--- a/examples/blog.rs
+++ b/examples/blog.rs
@@ -12,6 +12,17 @@ enum Schema {
         #[version(1..)]
         email: String,
     },
+    Story {
+        author: User,
+        title: String,
+        content: String,
+    },
+    #[unique(user, story)]
+    Rating {
+        user: User,
+        story: Story,
+        stars: i64,
+    },
 }
 use v0::*;
 

--- a/examples/query_optional.rs
+++ b/examples/query_optional.rs
@@ -48,6 +48,9 @@ fn main() {
     let txn = client.transaction(&database);
     let score = txn.query_one(optional(|row| {
         let player = row.and(Player::unique(pub_id));
-        row.then_dummy(PlayerInfo::dummy(player))
+        row.then_dummy(PlayerInfoDummy {
+            name: player.name(),
+            score: player.score(),
+        })
     }));
 }

--- a/examples/query_optional.rs
+++ b/examples/query_optional.rs
@@ -1,6 +1,6 @@
 use rust_query::{
     migration::{schema, Config},
-    optional, Database, FromDummy, IntoColumn, LocalClient,
+    optional, Database, FromDummy, LocalClient,
 };
 
 // Start by defining your schema.
@@ -11,6 +11,10 @@ enum Schema {
         pub_id: i64,
         name: String,
         score: i64,
+        home: World,
+    },
+    World {
+        name: String,
     },
 }
 // Bring the latest schema version into scope.
@@ -30,10 +34,17 @@ fn main() {
     let txn = client.transaction(&database);
 
     #[derive(FromDummy)]
+    #[trivial(World)]
+    struct WorldInfo {
+        name: String,
+    }
+
+    #[derive(FromDummy)]
     #[trivial(Player)]
     struct PlayerInfo {
         name: String,
         score: i64,
+        home: WorldInfo,
     }
 
     // old pattern, requires two queries
@@ -42,6 +53,9 @@ fn main() {
         txn.query_one(PlayerInfoDummy {
             name: player.name(),
             score: player.score(),
+            home: WorldInfoDummy {
+                name: player.home().name(),
+            },
         })
     });
 
@@ -51,6 +65,7 @@ fn main() {
         row.then_dummy(PlayerInfoDummy {
             name: player.name(),
             score: player.score(),
+            home: player.home().trivial(),
         })
     }));
 

--- a/examples/query_optional.rs
+++ b/examples/query_optional.rs
@@ -48,6 +48,6 @@ fn main() {
     let txn = client.transaction(&database);
     let score = txn.query_one(optional(|row| {
         let player = row.and(Player::unique(pub_id));
-        row.then(player.score())
+        row.then_dummy(PlayerInfo::dummy(player))
     }));
 }

--- a/examples/query_optional.rs
+++ b/examples/query_optional.rs
@@ -39,7 +39,7 @@ fn main() {
 
     let mut client = LocalClient::try_new().unwrap();
     let database: Database<Schema> = client
-        .migrator(Config::open("my_database.sqlite"))
+        .migrator(Config::open_in_memory())
         .expect("database version is before supported versions")
         // migrations go here
         .finish()

--- a/examples/query_optional.rs
+++ b/examples/query_optional.rs
@@ -37,4 +37,12 @@ fn main() {
     }
 
     let info: Option<PlayerInfo> = txn.query_one(Player::unique(pub_id).trivial());
+
+    let info = txn.query_one(optional(|row| {
+        let player = row.and(Player::unique(pub_id));
+        row.then_dummy(PlayerInfoDummy {
+            name: player.name(),
+            score: player.score(),
+        })
+    }));
 }

--- a/rust-query-macros/src/dummy.rs
+++ b/rust-query-macros/src/dummy.rs
@@ -104,20 +104,19 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
         let mut trivial_prepared = vec![];
         for (name, typ) in fields {
             trivial_types.push(
-                quote! {<#typ as ::rust_query::private::FromColumn<#transaction_lt, #schema>>::Prepared<'_i>},
+                quote! {<#typ as ::rust_query::private::FromColumn<#transaction_lt, #schema>>::Dummy<'_t>},
             );
             trivial_prepared
-                .push(quote! {#name: <#typ as ::rust_query::private::FromColumn<#schema>>::prepare(col.#name(), cacher)}); 
+                .push(quote! {#name: <#typ as ::rust_query::private::FromColumn<#schema>>::from_column(col.#name())}); 
         }
         quote! {
             impl<#(#original_plus_transaction),*> ::rust_query::private::FromColumn<#transaction_lt, #schema> for #name<#(#original_generics),*> {
                 type From = #trivial;
-                type Prepared<'_i> = #dummy_name<#(#trivial_types),*>;
+                type Dummy<'_t> = #dummy_name<#(#trivial_types),*>;
     
-                fn prepare<'_i, '_t>(
+                fn from_column<'_t>(
                     col: ::rust_query::Column<'_t, #schema, Self::From>,
-                    cacher: &mut ::rust_query::private::Cacher<'_t, '_i, #schema>,
-                ) -> Self::Prepared<'_i> {
+                ) -> Self::Dummy<'_t> {
                     #dummy_name {
                         #(#trivial_prepared,)*
                     }

--- a/rust-query-macros/src/dummy.rs
+++ b/rust-query-macros/src/dummy.rs
@@ -49,7 +49,7 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
         impl<'_t, '_a #(,#original_generics)*, S #(,#constraints)*> ::rust_query::private::Dummy<'_t, '_a, S> for #dummy_name<#(#generics),*> {
             type Out = #name<#(#original_generics),*>;
 
-            fn prepare<'_i>(self, mut cacher: &::rust_query::private::Cacher<'_t, '_i, S>) ->
+            fn prepare<'_i>(self, mut cacher: &mut ::rust_query::private::Cacher<'_t, '_i, S>) ->
                     Box<dyn '_i + FnMut(::rust_query::private::Row<'_, '_i, '_a>) -> ::rust_query::private::Wrapped<'_i, Self::Out>> {
                 #(#prepared;)*
                 Box::new(move |row| ::rust_query::private::Wrapped::new(#name {

--- a/rust-query-macros/src/dummy.rs
+++ b/rust-query-macros/src/dummy.rs
@@ -38,7 +38,7 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
         constraints.push(quote! {#generic: ::rust_query::private::Dummy<'_t, '_a, S, Out = #typ>});
         generics.push(generic);
         prepared.push(quote! {let mut #name_prepared = ::rust_query::private::Dummy::prepare(self.#name, cacher)});
-        inits.push(quote! {#name: (#name_prepared)(row).0});
+        inits.push(quote! {#name: #name_prepared.call(row).0});
     }
 
     Ok(quote! {
@@ -50,9 +50,9 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
             type Out = #name<#(#original_generics),*>;
 
             fn prepare<'_i>(self, mut cacher: &mut ::rust_query::private::Cacher<'_t, '_i, S>) ->
-                    Box<dyn '_i + FnMut(::rust_query::private::Row<'_, '_i, '_a>) -> ::rust_query::private::Wrapped<'_i, Self::Out>> {
+                    ::rust_query::private::Prepared<'_i, '_a, Self::Out> {
                 #(#prepared;)*
-                Box::new(move |row| ::rust_query::private::Wrapped::new(#name {
+                ::rust_query::private::Prepared::new(move |row| ::rust_query::private::Wrapped::new(#name {
                     #(#inits,)*
                 }))
             }

--- a/rust-query-macros/src/dummy.rs
+++ b/rust-query-macros/src/dummy.rs
@@ -38,7 +38,7 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
         constraints.push(quote! {#generic: ::rust_query::private::Dummy<'_t, '_a, S, Out = #typ>});
         generics.push(generic);
         prepared.push(quote! {let mut #name_prepared = ::rust_query::private::Dummy::prepare(self.#name, cacher)});
-        inits.push(quote! {#name: (#name_prepared)(row)});
+        inits.push(quote! {#name: (#name_prepared)(row).0});
     }
 
     Ok(quote! {
@@ -50,11 +50,11 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
             type Out = #name<#(#original_generics),*>;
 
             fn prepare<'_i>(self, mut cacher: &::rust_query::private::Cacher<'_t, '_i, S>) ->
-                    Box<dyn '_i + FnMut(::rust_query::private::Row<'_, '_i, '_a>) -> Self::Out> {
+                    Box<dyn '_i + FnMut(::rust_query::private::Row<'_, '_i, '_a>) -> ::rust_query::private::Wrapped<'_i, Self::Out>> {
                 #(#prepared;)*
-                Box::new(move |row| #name {
+                Box::new(move |row| ::rust_query::private::Wrapped::new(#name {
                     #(#inits,)*
-                })
+                }))
             }
         }
     })

--- a/rust-query-macros/src/dummy.rs
+++ b/rust-query-macros/src/dummy.rs
@@ -21,6 +21,8 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
     let mut defs = vec![];
     let mut generics = vec![];
     let mut constraints = vec![];
+    let mut constraints_prepared = vec![];
+    let mut prepared_typ = vec![];
     let mut prepared = vec![];
     let mut inits = vec![];
     for field in item.fields {
@@ -30,15 +32,17 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
                 "Tuple structs are not supported (yet).",
             ));
         };
-        let name_prepared = format_ident!("{name}_prepared");
         let generic = make_generic(&name);
         let typ = field.ty;
 
         defs.push(quote! {#name: #generic});
         constraints.push(quote! {#generic: ::rust_query::private::Dummy<'_t, '_a, S, Out = #typ>});
+        constraints_prepared
+            .push(quote! {#generic: ::rust_query::private::Prepared<'_i, '_a, Out = #typ>});
+        prepared_typ.push(quote! {#generic::Prepared<'_i>});
         generics.push(generic);
-        prepared.push(quote! {let mut #name_prepared = ::rust_query::private::Dummy::prepare(self.#name, cacher)});
-        inits.push(quote! {#name: #name_prepared.call(row)});
+        prepared.push(quote! {#name: ::rust_query::private::Dummy::prepare(self.#name, cacher)});
+        inits.push(quote! {#name: self.#name.call(row)});
     }
 
     Ok(quote! {
@@ -46,15 +50,25 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
             #(#defs),*
         }
 
-        impl<'_t, '_a #(,#original_generics)*, S #(,#constraints)*> ::rust_query::private::Dummy<'_t, '_a, S> for #dummy_name<#(#generics),*> {
+        impl<'_i, '_a #(,#original_generics)* #(,#constraints_prepared)*> ::rust_query::private::Prepared<'_i, '_a> for #dummy_name<#(#generics),*> {
             type Out = #name<#(#original_generics),*>;
 
-            fn prepare<'_i>(self, mut cacher: &mut ::rust_query::private::Cacher<'_t, '_i, S>) ->
-                    ::rust_query::private::Prepared<'_i, '_a, Self::Out> {
-                #(#prepared;)*
-                ::rust_query::private::Prepared::new(move |row| #name {
+            fn call(&mut self, row: ::rust_query::private::Row<'_, '_i, '_a>) -> Self::Out {
+                #name {
                     #(#inits,)*
-                })
+                }
+            }
+        }
+
+
+        impl<'_t, '_a #(,#original_generics)*, S #(,#constraints)*> ::rust_query::private::Dummy<'_t, '_a, S> for #dummy_name<#(#generics),*> {
+            type Out = #name<#(#original_generics),*>;
+            type Prepared<'_i> = #dummy_name<#(#prepared_typ),*>;
+
+            fn prepare<'_i>(self, mut cacher: &mut ::rust_query::private::Cacher<'_t, '_i, S>) -> Self::Prepared<'_i> {
+                #dummy_name {
+                    #(#prepared,)*
+                }
             }
         }
     })

--- a/rust-query-macros/src/dummy.rs
+++ b/rust-query-macros/src/dummy.rs
@@ -38,7 +38,7 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
         constraints.push(quote! {#generic: ::rust_query::private::Dummy<'_t, '_a, S, Out = #typ>});
         generics.push(generic);
         prepared.push(quote! {let mut #name_prepared = ::rust_query::private::Dummy::prepare(self.#name, cacher)});
-        inits.push(quote! {#name: #name_prepared.call(row).0});
+        inits.push(quote! {#name: #name_prepared.call(row)});
     }
 
     Ok(quote! {
@@ -52,9 +52,9 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
             fn prepare<'_i>(self, mut cacher: &mut ::rust_query::private::Cacher<'_t, '_i, S>) ->
                     ::rust_query::private::Prepared<'_i, '_a, Self::Out> {
                 #(#prepared;)*
-                ::rust_query::private::Prepared::new(move |row| ::rust_query::private::Wrapped::new(#name {
+                ::rust_query::private::Prepared::new(move |row| #name {
                     #(#inits,)*
-                }))
+                })
             }
         }
     })

--- a/rust-query-macros/src/dummy.rs
+++ b/rust-query-macros/src/dummy.rs
@@ -92,13 +92,13 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
         let mut trivial_prepared = vec![];
         for (name, typ) in fields {
             trivial_types.push(
-                quote! {<#typ as ::rust_query::private::FromDummy<'_a, #schema>>::Prepared<'_i>},
+                quote! {<#typ as ::rust_query::private::FromColumn<'_a, #schema>>::Prepared<'_i>},
             );
             trivial_prepared
-            .push(quote! {#name: <#typ as ::rust_query::private::FromDummy<#schema>>::prepare(col.#name(), cacher)}); 
+            .push(quote! {#name: <#typ as ::rust_query::private::FromColumn<#schema>>::prepare(col.#name(), cacher)}); 
         }
         quote! {
-            impl<'_a #(,#original_generics)*> ::rust_query::private::FromDummy<'_a, #schema> for #name<#(#original_generics),*> {
+            impl<'_a #(,#original_generics)*> ::rust_query::private::FromColumn<'_a, #schema> for #name<#(#original_generics),*> {
                 type From = #trivial;
                 type Prepared<'_i> = #dummy_name<#(#trivial_types),*>;
     

--- a/rust-query-macros/src/dummy.rs
+++ b/rust-query-macros/src/dummy.rs
@@ -1,22 +1,73 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{GenericParam, ItemStruct};
+use syn::{parse::Parse, GenericParam, ItemStruct, Lifetime};
 
 use crate::make_generic;
 
+struct CommonInfo {
+    name: syn::Ident,
+    dummy_name: syn::Ident,
+    original_generics: Vec<Lifetime>,
+    fields: Vec<(syn::Ident, syn::Type)>,
+}
+
+impl CommonInfo {
+    fn from_item(item: ItemStruct) -> syn::Result<Self> {
+        let name = item.ident;
+        let dummy_name = format_ident!("{name}Dummy");
+        let original_generics = item.generics.params.into_iter().map(|x| {
+            let GenericParam::Lifetime(lt) = x else {
+                return Err(syn::Error::new_spanned(
+                    x,
+                    "Only lifetime generics are supported.",
+                ));
+            };
+            Ok(lt.lifetime)
+        });
+        let fields = item.fields.into_iter().map(|field| {
+            let Some(name) = field.ident else {
+                return Err(syn::Error::new_spanned(
+                    field,
+                    "Tuple structs are not supported (yet).",
+                ));
+            };
+            Ok((name, field.ty))
+        });
+        Ok(Self {
+            name,
+            dummy_name,
+            original_generics: original_generics.collect::<Result<_, _>>()?,
+            fields: fields.collect::<Result<_, _>>()?,
+        })
+    }
+}
+
 pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
-    let name = item.ident;
-    let dummy_name = format_ident!("{name}Dummy");
-    let original_generics = item.generics.params.iter().map(|x| {
-        let GenericParam::Lifetime(lt) = x else {
-            return Err(syn::Error::new_spanned(
-                x,
-                "Only lifetime generics are supported.",
-            ));
-        };
-        Ok(lt.lifetime.clone())
-    });
-    let original_generics: Vec<_> = original_generics.collect::<Result<_, _>>()?;
+    let mut trivial = None;
+    for attr in &item.attrs {
+        if attr.path().is_ident("trivial") {
+            if trivial
+                .replace(attr.parse_args_with(syn::Path::parse)?)
+                .is_some()
+            {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "Can not have multiple `trivial` attributes.",
+                ));
+            }
+        }
+    }
+
+    if let Some(trivial) = trivial {
+        return impl_trivial(item, trivial);
+    }
+
+    let CommonInfo {
+        name,
+        dummy_name,
+        original_generics,
+        fields,
+    } = CommonInfo::from_item(item)?;
 
     let mut defs = vec![];
     let mut generics = vec![];
@@ -25,15 +76,8 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
     let mut prepared_typ = vec![];
     let mut prepared = vec![];
     let mut inits = vec![];
-    for field in item.fields {
-        let Some(name) = field.ident else {
-            return Err(syn::Error::new_spanned(
-                field,
-                "Tuple structs are not supported (yet).",
-            ));
-        };
+    for (name, typ) in fields {
         let generic = make_generic(&name);
-        let typ = field.ty;
 
         defs.push(quote! {#name: #generic});
         constraints.push(quote! {#generic: ::rust_query::private::Dummy<'_t, '_a, S, Out = #typ>});
@@ -66,6 +110,59 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
             type Prepared<'_i> = #dummy_name<#(#prepared_typ),*>;
 
             fn prepare<'_i>(self, mut cacher: &mut ::rust_query::private::Cacher<'_t, '_i, S>) -> Self::Prepared<'_i> {
+                #dummy_name {
+                    #(#prepared,)*
+                }
+            }
+        }
+    })
+}
+
+fn impl_trivial(item: ItemStruct, trivial: syn::Path) -> syn::Result<TokenStream> {
+    let CommonInfo {
+        name,
+        dummy_name,
+        original_generics,
+        fields,
+    } = CommonInfo::from_item(item)?;
+    let schema = quote! {<#trivial as ::rust_query::Table>::Schema};
+
+    let mut defs = vec![];
+    let mut prepared = vec![];
+    let mut inits = vec![];
+    for (name, typ) in fields {
+        defs.push(
+            quote! {#name: <#typ as ::rust_query::private::FromDummy<'_a, #schema>>::Prepared<'_i>},
+        );
+        prepared
+            .push(quote! {#name: <#typ as ::rust_query::private::FromDummy<#schema>>::prepare(col.#name(), cacher)});
+        inits.push(quote! {#name: self.#name.call(row)});
+    }
+
+    Ok(quote! {
+        struct #dummy_name<'_i, '_a #(,#original_generics)*> {
+            #(#defs),*
+        }
+
+        impl<'_i, '_a #(,#original_generics)*> ::rust_query::private::Prepared<'_i, '_a> for #dummy_name<'_i, '_a #(,#original_generics)*> {
+            type Out = #name<#(#original_generics),*>;
+
+            fn call(&mut self, row: ::rust_query::private::Row<'_, '_i, '_a>) -> Self::Out {
+                #name {
+                    #(#inits,)*
+                }
+            }
+        }
+
+
+        impl<'_a #(,#original_generics)*> ::rust_query::private::FromDummy<'_a, #schema> for #name<#(#original_generics),*> {
+            type From = #trivial;
+            type Prepared<'_i> = #dummy_name<'_i, '_a #(,#original_generics)*>;
+
+            fn prepare<'_i, '_t>(
+                col: ::rust_query::Column<'_t, #schema, Self::From>,
+                cacher: &mut ::rust_query::private::Cacher<'_t, '_i, #schema>,
+            ) -> Self::Prepared<'_i> {
                 #dummy_name {
                     #(#prepared,)*
                 }

--- a/rust-query-macros/src/dummy.rs
+++ b/rust-query-macros/src/dummy.rs
@@ -90,12 +90,17 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
 
         let mut trivial_types = vec![];
         let mut trivial_prepared = vec![];
+        let mut trivial_conds = vec![];
         for (name, typ) in fields {
             trivial_types.push(
                 quote! {<#typ as ::rust_query::private::FromColumn<'_a, #schema>>::Prepared<'_i>},
             );
             trivial_prepared
             .push(quote! {#name: <#typ as ::rust_query::private::FromColumn<#schema>>::prepare(col.#name(), cacher)}); 
+        trivial_conds.push(quote! {
+            #typ: ::rust_query::private::FromColumn<'_a, #schema>
+        });
+            
         }
         quote! {
             impl<'_a #(,#original_generics)*> ::rust_query::private::FromColumn<'_a, #schema> for #name<#(#original_generics),*> {

--- a/rust-query-macros/src/dummy.rs
+++ b/rust-query-macros/src/dummy.rs
@@ -49,11 +49,12 @@ pub fn from_row_impl(item: ItemStruct) -> syn::Result<TokenStream> {
         impl<'_t, '_a #(,#original_generics)*, S #(,#constraints)*> ::rust_query::private::Dummy<'_t, '_a, S> for #dummy_name<#(#generics),*> {
             type Out = #name<#(#original_generics),*>;
 
-            fn prepare(self, mut cacher: ::rust_query::private::Cacher<'_, '_t, S>) -> impl FnMut(::rust_query::private::Row<'_, '_t, '_a>) -> Self::Out + '_t {
+            fn prepare<'_i>(self, mut cacher: &::rust_query::private::Cacher<'_t, '_i, S>) ->
+                    Box<dyn '_i + FnMut(::rust_query::private::Row<'_, '_i, '_a>) -> Self::Out> {
                 #(#prepared;)*
-                move |row| #name {
+                Box::new(move |row| #name {
                     #(#inits,)*
-                }
+                })
             }
         }
     })

--- a/rust-query-macros/src/lib.rs
+++ b/rust-query-macros/src/lib.rs
@@ -212,7 +212,7 @@ pub fn schema(
 ///     })
 /// }
 /// ```
-#[proc_macro_derive(FromDummy, attributes(trivial))]
+#[proc_macro_derive(FromDummy, attributes(trivial, transaction))]
 pub fn from_row(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let item = syn::parse_macro_input!(item as ItemStruct);
     match from_row_impl(item) {

--- a/rust-query-macros/src/lib.rs
+++ b/rust-query-macros/src/lib.rs
@@ -384,15 +384,14 @@ fn define_table_migration(
                 type From = #prev_typ;
                 type To = super::#table_name;
 
-                fn prepare(
+                fn prepare<'i>(
                     self: Box<Self>,
-                    prev: ::rust_query::private::Cached<'t, Self::From>,
-                    cacher: ::rust_query::private::Cacher<'_, 't, <Self::From as ::rust_query::Table>::Schema>,
+                    prev: ::rust_query::private::Cached<'i, Self::From>,
+                    cacher: &::rust_query::private::Cacher<'t, 'i, <Self::From as ::rust_query::Table>::Schema>,
                 ) -> Box<
-                    dyn FnMut(::rust_query::private::Row<'_, 't, 'a>, ::rust_query::private::Reader<'_, 't, <Self::From as ::rust_query::Table>::Schema>) + 't,
+                    dyn 'i
+                        + FnMut(::rust_query::private::Row<'_, 'i, 'a>, ::rust_query::private::Reader<'_, 'i, <Self::From as ::rust_query::Table>::Schema>),
                 >
-                where
-                    'a: 't
                 {
                     #(#prepare;)*
                     Box::new(move |row, reader| {
@@ -408,14 +407,13 @@ fn define_table_migration(
                 type FromSchema = _PrevSchema;
                 type To = super::#table_name;
 
-                fn prepare(
+                fn prepare<'i>(
                     self: Box<Self>,
-                    cacher: ::rust_query::private::Cacher<'_, 't, Self::FromSchema>,
+                    cacher: &::rust_query::private::Cacher<'t, 'i, Self::FromSchema>,
                 ) -> Box<
-                    dyn FnMut(::rust_query::private::Row<'_, 't, 'a>, ::rust_query::private::Reader<'_, 't, Self::FromSchema>) + 't,
+                    dyn 'i
+                        + FnMut(::rust_query::private::Row<'_, 'i, 'a>, ::rust_query::private::Reader<'_, 'i, Self::FromSchema>),
                 >
-                where
-                    'a: 't
                 {
                     #(#prepare;)*
                     Box::new(move |row, reader| {

--- a/rust-query-macros/src/lib.rs
+++ b/rust-query-macros/src/lib.rs
@@ -387,7 +387,7 @@ fn define_table_migration(
                 fn prepare<'i>(
                     self: Box<Self>,
                     prev: ::rust_query::private::Cached<'i, Self::From>,
-                    cacher: &::rust_query::private::Cacher<'t, 'i, <Self::From as ::rust_query::Table>::Schema>,
+                    cacher: &mut ::rust_query::private::Cacher<'t, 'i, <Self::From as ::rust_query::Table>::Schema>,
                 ) -> Box<
                     dyn 'i
                         + FnMut(::rust_query::private::Row<'_, 'i, 'a>, ::rust_query::private::Reader<'_, 'i, <Self::From as ::rust_query::Table>::Schema>),
@@ -409,7 +409,7 @@ fn define_table_migration(
 
                 fn prepare<'i>(
                     self: Box<Self>,
-                    cacher: &::rust_query::private::Cacher<'t, 'i, Self::FromSchema>,
+                    cacher: &mut ::rust_query::private::Cacher<'t, 'i, Self::FromSchema>,
                 ) -> Box<
                     dyn 'i
                         + FnMut(::rust_query::private::Row<'_, 'i, 'a>, ::rust_query::private::Reader<'_, 'i, Self::FromSchema>),

--- a/rust-query-macros/src/lib.rs
+++ b/rust-query-macros/src/lib.rs
@@ -212,7 +212,7 @@ pub fn schema(
 ///     })
 /// }
 /// ```
-#[proc_macro_derive(FromDummy)]
+#[proc_macro_derive(FromDummy, attributes(trivial))]
 pub fn from_row(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let item = syn::parse_macro_input!(item as ItemStruct);
     match from_row_impl(item) {

--- a/rust-query-macros/src/lib.rs
+++ b/rust-query-macros/src/lib.rs
@@ -364,7 +364,7 @@ fn define_table_migration(
             prepare.push(
                 quote! {let mut #prepared_name = ::rust_query::Dummy::prepare(self.#name, cacher)},
             );
-            into_new.push(quote! {reader.col(#name_str, #prepared_name(row))});
+            into_new.push(quote! {reader.col(#name_str, #prepared_name(row).0)});
         }
     }
 

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use sea_query::Iden;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) enum Field {
     U64(MyAlias),
     Str(&'static str),
@@ -29,7 +29,7 @@ impl Scope {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MyAlias {
     name: u64,
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -49,7 +49,7 @@ impl MySelect {
         ValueBuilder { inner: self }
     }
 
-    pub fn cache(&self, exprs: Vec<DynTypedExpr>) -> Vec<Field> {
+    pub fn cache(&self, exprs: impl IntoIterator<Item = DynTypedExpr>) -> Vec<Field> {
         exprs
             .into_iter()
             .map(|val| {

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -113,12 +113,9 @@ pub struct MapPrepared<X, M> {
 
 pub trait FromColumn<'transaction, S> {
     type From: 'static;
-    type Prepared<'i>: Prepared<'i, 'transaction, Out = Self>;
+    type Dummy<'columns>: Dummy<'columns, 'transaction, S, Out = Self>;
 
-    fn prepare<'i, 'columns>(
-        col: Column<'columns, S, Self::From>,
-        cacher: &mut Cacher<'columns, 'i, S>,
-    ) -> Self::Prepared<'i>;
+    fn from_column<'columns>(col: Column<'columns, S, Self::From>) -> Self::Dummy<'columns>;
 }
 
 impl<'transaction, X, M, Out> Prepared<'static, 'transaction> for MapPrepared<X, M>
@@ -149,7 +146,7 @@ impl<'i, 'a, X: Prepared<'static, 'a>> Prepared<'i, 'a> for DynDummy<'i, X> {
 }
 
 /// Erases the `'i` lifetime
-/// TODO: Remove this type?
+/// TODO: Make this type private
 pub struct PubDummy<'columns, S, X> {
     pub(crate) columns: Vec<DynTypedExpr>,
     pub(crate) inner: X,

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -5,7 +5,7 @@ use sea_query::Iden;
 use crate::{
     alias::Field,
     value::{DynTypedExpr, MyTyp},
-    IntoColumn,
+    Column, IntoColumn,
 };
 
 pub struct Cacher<'t, 'i, S> {
@@ -109,6 +109,16 @@ pub trait Dummy<'columns, 'transaction, S>: Sized {
 pub struct MapPrepared<X, M> {
     inner: X,
     map: M,
+}
+
+pub trait FromDummy<'transaction> {
+    type From;
+    type Prepared<'i>: Prepared<'i, 'transaction, Out = Self>;
+
+    fn prepare<'i, 'columns, S>(
+        col: Column<'columns, S, Self::From>,
+        cacher: &mut Cacher<'columns, 'i, S>,
+    ) -> Self::Prepared<'i>;
 }
 
 impl<'transaction, X, M, Out> Prepared<'static, 'transaction> for MapPrepared<X, M>

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -63,9 +63,9 @@ impl<'t, 'a> Row<'_, 't, 'a> {
 }
 
 /// Add the implied bound `T: 'i` which can not be added as `Self::Out: 'i` for some reason
-struct Wrapped<'i, T>(pub(crate) T, pub(crate) PhantomData<&'i T>);
+pub struct Wrapped<'i, T>(pub T, pub(crate) PhantomData<&'i T>);
 impl<'i, T> Wrapped<'i, T> {
-    fn new(val: T) -> Self {
+    pub fn new(val: T) -> Self {
         Self(val, PhantomData)
     }
 }

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -111,7 +111,7 @@ pub struct MapPrepared<X, M> {
     map: M,
 }
 
-pub trait FromDummy<'transaction, S> {
+pub trait FromColumn<'transaction, S> {
     type From: 'static;
     type Prepared<'i>: Prepared<'i, 'transaction, Out = Self>;
 

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -66,10 +66,10 @@ impl<'x, 'i, 'a> Row<'x, 'i, 'a> {
     }
 }
 
-pub trait Prepared<'i, 'a> {
+pub trait Prepared<'i, 'transaction> {
     type Out;
 
-    fn call(&mut self, row: Row<'_, 'i, 'a>) -> Self::Out;
+    fn call(&mut self, row: Row<'_, 'i, 'transaction>) -> Self::Out;
 }
 
 /// This trait is implemented by everything that can be retrieved from the database.

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -79,6 +79,7 @@ pub trait Dummy<'columns, 'transaction, S>: Sized {
     /// The type that results from querying this dummy.
     type Out;
 
+    #[doc(hidden)]
     type Prepared<'i>: Prepared<'i, 'transaction, Out = Self::Out>;
 
     #[doc(hidden)]
@@ -144,8 +145,8 @@ pub struct PubDummy<'columns, S, X> {
     pub(crate) _p2: PhantomData<S>,
 }
 
-impl<'collumns, S, X> PubDummy<'collumns, S, X> {
-    pub fn new<'a>(val: impl Dummy<'collumns, 'a, S, Prepared<'static> = X>) -> Self {
+impl<'columns, S, X> PubDummy<'columns, S, X> {
+    pub fn new<'a>(val: impl Dummy<'columns, 'a, S, Prepared<'static> = X>) -> Self {
         let mut cacher = Cacher {
             _p: PhantomData,
             _p2: PhantomData,
@@ -160,8 +161,8 @@ impl<'collumns, S, X> PubDummy<'collumns, S, X> {
     }
 }
 
-impl<'collumns, 'transaction, S, X: Prepared<'static, 'transaction>>
-    Dummy<'collumns, 'transaction, S> for PubDummy<'collumns, S, X>
+impl<'columns, 'transaction, S, X: Prepared<'static, 'transaction>> Dummy<'columns, 'transaction, S>
+    for PubDummy<'columns, S, X>
 {
     type Out = X::Out;
     type Prepared<'i> = DynDummy<X>;

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -138,6 +138,7 @@ impl<'i, 'a, X: Prepared<'static, 'a>> Prepared<'i, 'a> for DynDummy<X> {
 }
 
 /// Erases the `'i` lifetime
+/// TODO: Remove this type?
 pub struct PubDummy<'columns, S, X> {
     pub(crate) columns: Vec<DynTypedExpr>,
     pub(crate) inner: X,

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -92,7 +92,7 @@ pub trait Dummy<'columns, 'transaction, S>: Sized {
     fn map_dummy<T, F: FnMut(Self::Out) -> T>(
         self,
         f: F,
-    ) -> impl Dummy<'columns, 'transaction, S, Out = T> {
+    ) -> PubDummy<'columns, S, MapPrepared<Self::Prepared<'static>, F>> {
         let d = PubDummy::new(self);
         PubDummy {
             columns: d.columns,

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -92,7 +92,7 @@ pub trait Dummy<'columns, 'transaction, S>: Sized {
     fn map_dummy<T, F: FnMut(Self::Out) -> T>(
         self,
         f: F,
-    ) -> PubDummy<'columns, S, MapPrepared<Self::Prepared<'static>, F>> {
+    ) -> impl Dummy<'columns, 'transaction, S, Out = T> {
         let d = PubDummy::new(self);
         PubDummy {
             columns: d.columns,

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -15,8 +15,8 @@ pub struct Cacher<'t, 'i, S> {
 }
 
 pub struct Cached<'t, T> {
-    _p: PhantomData<fn(&'t T) -> &'t T>,
-    idx: usize,
+    pub(crate) _p: PhantomData<fn(&'t T) -> &'t T>,
+    pub(crate) idx: usize,
 }
 
 impl<'t, T> Clone for Cached<'t, T> {
@@ -46,7 +46,6 @@ impl<'t, 'i, S> Cacher<'t, 'i, S> {
 #[derive(Clone, Copy)]
 pub struct Row<'x, 'i, 'a> {
     pub(crate) _p: PhantomData<fn(&'i ()) -> &'a ()>,
-    pub(crate) _p2: PhantomData<&'i &'a ()>,
     pub(crate) row: &'x rusqlite::Row<'x>,
     pub(crate) mapping: &'x [Field],
 }
@@ -61,15 +60,15 @@ impl<'i, 'a> Row<'_, 'i, 'a> {
 
 pub struct Prepared<'l, 'i, 'a, Out> {
     inner: Box<dyn 'l + FnMut(Row<'_, 'i, 'a>) -> Out>,
-    // _p: PhantomData<&'l Out>,
-    _p2: PhantomData<&'l &'i ()>,
+    _p1: PhantomData<&'l &'i ()>,
+    _p2: PhantomData<&'l &'a ()>,
 }
 
 impl<'l, 'i, 'a, Out> Prepared<'l, 'i, 'a, Out> {
     pub fn new(func: impl 'l + FnMut(Row<'_, 'i, 'a>) -> Out) -> Self {
         Prepared {
             inner: Box::new(func),
-            // _p: PhantomData,
+            _p1: PhantomData,
             _p2: PhantomData,
         }
     }
@@ -131,7 +130,6 @@ impl<'a, 'l, Out> DynDummy<'l, 'a, Out> {
                     row: row,
                     mapping: fields,
                     _p: PhantomData,
-                    _p2: PhantomData,
                 })
             }),
             _p: PhantomData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub mod migration {
 #[doc(hidden)]
 pub mod private {
     pub use crate::db::Col;
-    pub use crate::dummy::{Cached, Cacher, Dummy, FromDummy, Prepared, Row};
+    pub use crate::dummy::{Cached, Cacher, Dummy, FromColumn, Prepared, Row};
     pub use crate::hash::TypBuilder;
     pub use crate::hash::{hash_schema, KangarooHasher};
     pub use crate::migrate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub mod migration {
 #[doc(hidden)]
 pub mod private {
     pub use crate::db::Col;
-    pub use crate::dummy::{Cached, Cacher, Dummy, Row};
+    pub use crate::dummy::{Cached, Cacher, Dummy, Row, Wrapped};
     pub use crate::hash::TypBuilder;
     pub use crate::hash::{hash_schema, KangarooHasher};
     pub use crate::migrate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,8 @@ pub mod private {
     pub use crate::hash::TypBuilder;
     pub use crate::hash::{hash_schema, KangarooHasher};
     pub use crate::migrate::{
-        Migration, Schema, SchemaBuilder, TableCreation, TableMigration, TableTypBuilder, C, M,
+        Migration, Schema, SchemaBuilder, TableCreation, TableCreationBox, TableMigration,
+        TableMigrationBox, TableTypBuilder, C, M,
     };
     pub use crate::query::show_sql;
     pub use crate::value::{into_owned, new_column, MyTyp, Typed, ValueBuilder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use ref_cast::RefCast;
 pub use rows::Rows;
 pub use rust_query_macros::FromDummy;
 pub use transaction::{Database, Transaction, TransactionMut, TransactionWeak};
-pub use value::{optional, Column, IntoColumn, UnixEpoch};
+pub use value::{optional::optional, Column, IntoColumn, UnixEpoch};
 
 /// Types that are used as closure arguments.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub mod migration {
 #[doc(hidden)]
 pub mod private {
     pub use crate::db::Col;
-    pub use crate::dummy::{Cached, Cacher, Dummy, Row, Wrapped};
+    pub use crate::dummy::{Cached, Cacher, Dummy, Prepared, Row, Wrapped};
     pub use crate::hash::TypBuilder;
     pub use crate::hash::{hash_schema, KangarooHasher};
     pub use crate::migrate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub mod migration {
 #[doc(hidden)]
 pub mod private {
     pub use crate::db::Col;
-    pub use crate::dummy::{Cached, Cacher, Dummy, Prepared, Row, Wrapped};
+    pub use crate::dummy::{Cached, Cacher, Dummy, Prepared, Row};
     pub use crate::hash::TypBuilder;
     pub use crate::hash::{hash_schema, KangarooHasher};
     pub use crate::migrate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ pub mod private {
     pub use crate::hash::TypBuilder;
     pub use crate::hash::{hash_schema, KangarooHasher};
     pub use crate::migrate::{
-        Migration, Schema, SchemaBuilder, TableCreation, TableCreationBox, TableMigration,
-        TableMigrationBox, TableTypBuilder, C, M,
+        CacheAndRead, Migration, Schema, SchemaBuilder, TableCreation, TableMigration,
+        TableTypBuilder, C, M,
     };
     pub use crate::query::show_sql;
     pub use crate::value::{into_owned, new_column, MyTyp, Typed, ValueBuilder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,10 @@ mod transaction;
 mod value;
 mod writable;
 
-pub use crate::dummy::Dummy;
 pub use aggregate::aggregate;
 pub use client::LocalClient;
 pub use db::TableRow;
+pub use dummy::Dummy;
 use hash::TypBuilder;
 use ref_cast::RefCast;
 pub use rows::Rows;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub mod migration {
 #[doc(hidden)]
 pub mod private {
     pub use crate::db::Col;
-    pub use crate::dummy::{Cached, Cacher, Dummy, Prepared, Row};
+    pub use crate::dummy::{Cached, Cacher, Dummy, FromDummy, Prepared, Row};
     pub use crate::hash::TypBuilder;
     pub use crate::hash::{hash_schema, KangarooHasher};
     pub use crate::migrate::{

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -258,7 +258,7 @@ impl<'a> SchemaBuilder<'_, 'a> {
             let row = crate::private::Row {
                 _p: PhantomData,
                 row,
-                mapping: &cached,
+                fields: &cached,
             };
 
             let new_ast = MySelect::default();

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -86,9 +86,7 @@ impl<'t, 'a, FromSchema, To> TableCreation<'t, 'a> for NeverCreate<FromSchema, T
     fn prepare<'i>(
         self: Box<Self>,
         _: &Cacher<'t, 'i, Self::FromSchema>,
-    ) -> Box<dyn FnMut(crate::private::Row<'_, 'i, 'a>, Reader<'_, 'i, Self::FromSchema>) + 't>
-    where
-        'a: 't + 'i,
+    ) -> Box<dyn 'i + FnMut(crate::private::Row<'_, 'i, 'a>, Reader<'_, 'i, Self::FromSchema>)>
     {
         Box::new(|_, _| unreachable!())
     }
@@ -130,11 +128,9 @@ pub trait TableMigration<'t, 'a> {
         prev: Cached<'i, Self::From>,
         cacher: &Cacher<'t, 'i, <Self::From as Table>::Schema>,
     ) -> Box<
-        dyn FnMut(crate::private::Row<'_, 'i, 'a>, Reader<'_, 'i, <Self::From as Table>::Schema>)
-            + 't,
-    >
-    where
-        'a: 't;
+        dyn 'i
+            + FnMut(crate::private::Row<'_, 'i, 'a>, Reader<'_, 'i, <Self::From as Table>::Schema>),
+    >;
 }
 
 pub trait TableCreation<'t, 'a> {
@@ -144,9 +140,7 @@ pub trait TableCreation<'t, 'a> {
     fn prepare<'i>(
         self: Box<Self>,
         cacher: &Cacher<'t, 'i, Self::FromSchema>,
-    ) -> Box<dyn FnMut(crate::private::Row<'_, 'i, 'a>, Reader<'_, 'i, Self::FromSchema>) + 't>
-    where
-        'a: 't + 'i;
+    ) -> Box<dyn 'i + FnMut(crate::private::Row<'_, 'i, 'a>, Reader<'_, 'i, Self::FromSchema>)>;
 }
 
 struct Wrapper<'t, 'a, From: Table, To>(
@@ -161,9 +155,7 @@ impl<'t, 'a, From: Table, To> TableCreation<'t, 'a> for Wrapper<'t, 'a, From, To
     fn prepare<'i>(
         self: Box<Self>,
         cacher: &Cacher<'t, 'i, Self::FromSchema>,
-    ) -> Box<dyn FnMut(crate::private::Row<'_, 'i, 'a>, Reader<'_, 'i, Self::FromSchema>) + 't>
-    where
-        'a: 't + 'i,
+    ) -> Box<dyn 'i + FnMut(crate::private::Row<'_, 'i, 'a>, Reader<'_, 'i, Self::FromSchema>)>
     {
         let db_id = cacher.cache(self.1);
         let mut prepared = Box::new(self.0).prepare(db_id, cacher);

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,7 +8,7 @@ use sea_query::SqliteQueryBuilder;
 use sea_query_rusqlite::RusqliteBinder;
 
 use crate::{
-    dummy::{Dummy, DynDummy},
+    dummy::{Dummy, Prepared, PubDummy, Row},
     rows::Rows,
 };
 
@@ -40,21 +40,18 @@ impl<'outer, 'inner, S> Query<'outer, 'inner, S> {
     /// Types that implement [crate::IntoColumn], will also implement [Dummy].
     /// Tuples of two values also implement [Dummy]. If you want to return more
     /// than two values, then you should use a struct that derives [crate::FromDummy].
-    pub fn into_vec<'e, D>(&'inner self, dummy: D) -> Vec<D::Out>
+    pub fn into_vec<D>(&'inner self, dummy: D) -> Vec<D::Out>
     where
-        D: Dummy<'inner, 'e, 'outer, S>,
-        'outer: 'e,
+        D: Dummy<'inner, 'outer, S>,
     {
         self.into_vec_private(dummy)
     }
 
     pub(crate) fn into_vec_private<'x, 'l, D>(&'inner self, dummy: D) -> Vec<D::Out>
     where
-        D: Dummy<'x, 'l, 'outer, S>,
-        S: 'x,
-        'outer: 'l,
+        D: Dummy<'x, 'outer, S>,
     {
-        let mut d = DynDummy::new(dummy);
+        let mut d = PubDummy::new(dummy);
         let cached = self.ast.cache(d.columns);
 
         let select = self.ast.simple();
@@ -69,7 +66,7 @@ impl<'outer, 'inner, S> Query<'outer, 'inner, S> {
 
         let mut out = vec![];
         while let Some(row) = rows.next().unwrap() {
-            out.push((d.func)(row, &cached));
+            out.push(d.inner.call(Row::new(row, &cached)));
         }
         out
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -78,7 +78,7 @@ impl<'outer, 'inner, S> Query<'outer, 'inner, S> {
                 row,
                 mapping: &cached,
             };
-            out.push(f(row).0);
+            out.push(f.call(row).0);
         }
         out
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -52,7 +52,13 @@ impl<'outer, 'inner, S> Query<'outer, 'inner, S> {
         D: Dummy<'x, 'outer, S>,
         S: 'x,
     {
-        let mut f = dummy.prepare(Cacher::new(&self.ast));
+        let mut cacher = Cacher {
+            _p: PhantomData,
+            _p2: PhantomData,
+            columns: Vec::new(),
+        };
+        let mut f = dummy.prepare(&mut cacher);
+        let cached = self.ast.cache(cacher.columns);
 
         let select = self.ast.simple();
         let (sql, values) = select.build_rusqlite(SqliteQueryBuilder);
@@ -70,6 +76,7 @@ impl<'outer, 'inner, S> Query<'outer, 'inner, S> {
                 _p: PhantomData,
                 _p2: PhantomData,
                 row,
+                mapping: &cached,
             };
             out.push(f(row).0);
         }

--- a/src/query.rs
+++ b/src/query.rs
@@ -78,7 +78,7 @@ impl<'outer, 'inner, S> Query<'outer, 'inner, S> {
                 row,
                 mapping: &cached,
             };
-            out.push(f.call(row).0);
+            out.push(f.call(row));
         }
         out
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -71,7 +71,7 @@ impl<'outer, 'inner, S> Query<'outer, 'inner, S> {
                 _p2: PhantomData,
                 row,
             };
-            out.push(f(row));
+            out.push(f(row).0);
         }
         out
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -52,11 +52,7 @@ impl<'outer, 'inner, S> Query<'outer, 'inner, S> {
         D: Dummy<'x, 'outer, S>,
         S: 'x,
     {
-        let mut f = dummy.prepare(Cacher {
-            _p: PhantomData,
-            _p2: PhantomData,
-            ast: &self.ast,
-        });
+        let mut f = dummy.prepare(Cacher::new(&self.ast));
 
         let select = self.ast.simple();
         let (sql, values) = select.build_rusqlite(SqliteQueryBuilder);

--- a/src/schema_pragma.rs
+++ b/src/schema_pragma.rs
@@ -117,95 +117,94 @@ impl IndexInfoDummy<Column<'_, Pragma, IndexInfo>> {
 table! {IndexInfo, IndexInfoDummy, val => format!("pragma_index_info('{}', 'main')", val.0)}
 
 pub fn read_schema(conn: &Transaction<Pragma>) -> hash::Schema {
-    // #[derive(Clone, FromDummy)]
-    // struct Column {
-    //     name: String,
-    //     typ: String,
-    //     pk: bool,
-    //     notnull: bool,
-    // }
+    #[derive(Clone, FromDummy)]
+    struct Column {
+        name: String,
+        typ: String,
+        pk: bool,
+        notnull: bool,
+    }
 
-    // let tables = conn.query(|q| {
-    //     let table = q.join_custom(TableList);
-    //     q.filter(table.schema().eq("main"));
-    //     q.filter(table.r#type().eq("table"));
-    //     q.filter(table.name().eq("sqlite_schema").not());
-    //     q.into_vec(table.name())
-    // });
+    let tables = conn.query(|q| {
+        let table = q.join_custom(TableList);
+        q.filter(table.schema().eq("main"));
+        q.filter(table.r#type().eq("table"));
+        q.filter(table.name().eq("sqlite_schema").not());
+        q.into_vec(table.name())
+    });
 
-    // let mut output = hash::Schema::default();
+    let mut output = hash::Schema::default();
 
-    // for table_name in tables {
-    //     let mut columns = conn.query(|q| {
-    //         let table = q.join_custom(TableInfo(table_name.clone()));
+    for table_name in tables {
+        let mut columns = conn.query(|q| {
+            let table = q.join_custom(TableInfo(table_name.clone()));
 
-    //         q.into_vec(ColumnDummy {
-    //             name: table.name(),
-    //             typ: table.r#type(),
-    //             pk: table.pk().eq(0).not(),
-    //             notnull: table.notnull().eq(0).not(),
-    //         })
-    //     });
+            q.into_vec(ColumnDummy {
+                name: table.name(),
+                typ: table.r#type(),
+                pk: table.pk().eq(0).not(),
+                notnull: table.notnull().eq(0).not(),
+            })
+        });
 
-    //     let fks: HashMap<_, _> = conn
-    //         .query(|q| {
-    //             let fk = q.join_custom(ForeignKeyList(table_name.to_owned()));
-    //             q.into_vec((fk.from(), fk.table()))
-    //         })
-    //         .into_iter()
-    //         .collect();
+        let fks: HashMap<_, _> = conn
+            .query(|q| {
+                let fk = q.join_custom(ForeignKeyList(table_name.to_owned()));
+                q.into_vec((fk.from(), fk.table()))
+            })
+            .into_iter()
+            .collect();
 
-    //     let make_type = |col: &Column| match col.typ.as_str() {
-    //         "INTEGER" => hash::ColumnType::Integer,
-    //         "TEXT" => hash::ColumnType::String,
-    //         "REAL" => hash::ColumnType::Float,
-    //         t => panic!("unknown type {t}"),
-    //     };
+        let make_type = |col: &Column| match col.typ.as_str() {
+            "INTEGER" => hash::ColumnType::Integer,
+            "TEXT" => hash::ColumnType::String,
+            "REAL" => hash::ColumnType::Float,
+            t => panic!("unknown type {t}"),
+        };
 
-    //     // we only care about columns that are not a unique id and for which we know the type
-    //     columns.retain(|col| {
-    //         if col.pk {
-    //             assert_eq!(col.name, "id");
-    //             return false;
-    //         }
-    //         true
-    //     });
+        // we only care about columns that are not a unique id and for which we know the type
+        columns.retain(|col| {
+            if col.pk {
+                assert_eq!(col.name, "id");
+                return false;
+            }
+            true
+        });
 
-    //     let mut table_def = hash::Table::default();
-    //     for col in columns {
-    //         let def = hash::Column {
-    //             fk: fks.get(&col.name).map(|x| (x.clone(), "id".to_owned())),
-    //             typ: make_type(&col),
-    //             name: col.name,
-    //             nullable: !col.notnull,
-    //         };
-    //         table_def.columns.insert(def)
-    //     }
+        let mut table_def = hash::Table::default();
+        for col in columns {
+            let def = hash::Column {
+                fk: fks.get(&col.name).map(|x| (x.clone(), "id".to_owned())),
+                typ: make_type(&col),
+                name: col.name,
+                nullable: !col.notnull,
+            };
+            table_def.columns.insert(def)
+        }
 
-    //     let uniques = conn.query(|q| {
-    //         let index = q.join_custom(IndexList(table_name.clone()));
-    //         q.filter(index.unique());
-    //         q.filter(index.origin().eq("u"));
-    //         q.filter(index.partial().not());
-    //         q.into_vec(index.name())
-    //     });
+        let uniques = conn.query(|q| {
+            let index = q.join_custom(IndexList(table_name.clone()));
+            q.filter(index.unique());
+            q.filter(index.origin().eq("u"));
+            q.filter(index.partial().not());
+            q.into_vec(index.name())
+        });
 
-    //     for unique_name in uniques {
-    //         let columns = conn.query(|q| {
-    //             let col = q.join_custom(IndexInfo(unique_name));
-    //             let name = q.filter_some(col.name());
-    //             q.into_vec(name)
-    //         });
+        for unique_name in uniques {
+            let columns = conn.query(|q| {
+                let col = q.join_custom(IndexInfo(unique_name));
+                let name = q.filter_some(col.name());
+                q.into_vec(name)
+            });
 
-    //         let mut unique_def = hash::Unique::default();
-    //         for column in columns {
-    //             unique_def.columns.insert(column);
-    //         }
-    //         table_def.uniques.insert(unique_def);
-    //     }
+            let mut unique_def = hash::Unique::default();
+            for column in columns {
+                unique_def.columns.insert(column);
+            }
+            table_def.uniques.insert(unique_def);
+        }
 
-    //     output.tables.insert((table_name, table_def))
-    // }
-    // output
-    todo!()
+        output.tables.insert((table_name, table_def))
+    }
+    output
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -131,9 +131,10 @@ impl<'t, S> Transaction<'t, S> {
     ///
     /// Instead of using [Self::query_one] in a loop, it is better to
     /// call [Self::query] and return all results at once.
-    pub fn query_one<O>(&self, val: impl Dummy<'t, 't, S, Out = O>) -> O
+    pub fn query_one<'e, O>(&self, val: impl Dummy<'t, 'e, 't, S, Out = O>) -> O
     where
         S: 'static,
+        't: 'e,
     {
         // Theoretically this doesn't even need to be in a transaction.
         // We already have one though, so we must use it.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -131,10 +131,9 @@ impl<'t, S> Transaction<'t, S> {
     ///
     /// Instead of using [Self::query_one] in a loop, it is better to
     /// call [Self::query] and return all results at once.
-    pub fn query_one<'e, O>(&self, val: impl Dummy<'t, 'e, 't, S, Out = O>) -> O
+    pub fn query_one<'e, O>(&self, val: impl Dummy<'t, 't, S, Out = O>) -> O
     where
         S: 'static,
-        't: 'e,
     {
         // Theoretically this doesn't even need to be in a transaction.
         // We already have one though, so we must use it.

--- a/src/value.rs
+++ b/src/value.rs
@@ -13,7 +13,7 @@ use crate::{
     alias::{Field, MyAlias, RawAlias},
     ast::{MySelect, Source},
     db::{TableRow, TableRowInner},
-    dummy::FromDummy,
+    dummy::FromColumn,
     hash,
     migrate::NoTable,
     Table,
@@ -128,7 +128,7 @@ pub trait IntoColumn<'t, S>: Private + Clone {
 }
 
 impl<'t, S, T> Column<'t, S, T> {
-    pub fn trivial<'x, X: FromDummy<'x, S, From = T>>(&self) -> Trivial<'t, S, T, X> {
+    pub fn trivial<'x, X: FromColumn<'x, S, From = T>>(&self) -> Trivial<'t, S, T, X> {
         Trivial {
             col: self.clone(),
             _p: PhantomData,

--- a/src/value.rs
+++ b/src/value.rs
@@ -7,11 +7,13 @@ use std::{marker::PhantomData, ops::Deref, rc::Rc};
 use operations::{Add, And, AsFloat, Eq, Glob, IsNotNull, Like, Lt, Not, Or, UnwrapOr};
 use ref_cast::RefCast;
 use sea_query::{Alias, Expr, Nullable, SelectStatement, SimpleExpr};
+use trivial::Trivial;
 
 use crate::{
     alias::{Field, MyAlias, RawAlias},
     ast::{MySelect, Source},
     db::{TableRow, TableRowInner},
+    dummy::FromDummy,
     hash,
     migrate::NoTable,
     Table,
@@ -123,6 +125,15 @@ pub trait IntoColumn<'t, S>: Private + Clone {
 
     /// Turn this value into a [Column].
     fn into_column(self) -> Column<'t, S, Self::Typ>;
+}
+
+impl<'t, S, T> Column<'t, S, T> {
+    pub fn trivial<'x, X: FromDummy<'x, From = T>>(&self) -> Trivial<'t, S, T, X> {
+        Trivial {
+            col: self.clone(),
+            _p: PhantomData,
+        }
+    }
 }
 
 impl<'t, S, T: NumTyp> Column<'t, S, T> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -250,7 +250,6 @@ impl<'outer, 'inner, S> Optional<'outer, 'inner, S> {
             func: Box::new(move |row, fields| {
                 let row2 = Row {
                     _p: PhantomData,
-                    _p2: PhantomData,
                     row,
                     mapping: fields,
                 };

--- a/src/value.rs
+++ b/src/value.rs
@@ -590,9 +590,9 @@ impl MyTyp for NoTable {
     }
 }
 
-/// Values of this type reference a collumn in a query.
+/// Values of this type reference a column in a query.
 ///
-/// - The lifetime parameter `'t` specifies in which query the collumn exists.
+/// - The lifetime parameter `'t` specifies in which query the column exists.
 /// - The type parameter `S` specifies the expected schema of the query.
 /// - And finally the type paramter `T` specifies the type of the column.
 ///

--- a/src/value.rs
+++ b/src/value.rs
@@ -14,7 +14,7 @@ use crate::{
     db::{TableRow, TableRowInner},
     hash,
     migrate::NoTable,
-    Dummy, Table,
+    Table,
 };
 
 #[derive(Clone, Copy)]
@@ -241,21 +241,6 @@ impl<'outer, 'inner, S> Optional<'outer, 'inner, S> {
     //     todo!()
     // }
 }
-
-// struct OptionDummy<'inner, X>(DynTyped<bool>, X, PhantomData<&'inner ()>);
-// impl<'t, 'a, 'inner, S, X> Dummy<'t, 'a, S> for OptionDummy<'inner, X>
-// where
-//     X: Dummy<'inner, 'a, S>,
-// {
-//     type Out = Option<X::Out>;
-
-//     fn prepare(
-//         self,
-//         cacher: crate::dummy::Cacher<'_, 't, S>,
-//     ) -> impl FnMut(crate::dummy::Row<'_, 't, 'a>) -> Self::Out + 't {
-//         todo!()
-//     }
-// }
 
 impl<'t, S> Column<'t, S, i64> {
     /// Convert the [i64] column to [f64] type.

--- a/src/value.rs
+++ b/src/value.rs
@@ -12,7 +12,7 @@ use crate::{
     alias::{Field, MyAlias, RawAlias},
     ast::{MySelect, Source},
     db::{TableRow, TableRowInner},
-    dummy::{Cacher, DynDummy, Prepared, PubDummy, Row},
+    dummy::{Cacher, DynDummy, PubDummy, Row},
     hash,
     migrate::NoTable,
     Dummy, Table,
@@ -251,7 +251,7 @@ impl<'outer, 'inner, S> Optional<'outer, 'inner, S> {
                 let row2 = Row {
                     _p: PhantomData,
                     row,
-                    mapping: fields,
+                    fields,
                 };
                 if row2.get(is_some) {
                     Some((d.func)(row, fields))
@@ -259,14 +259,8 @@ impl<'outer, 'inner, S> Optional<'outer, 'inner, S> {
                     None
                 }
             }),
-            _p: PhantomData,
-            _p2: PhantomData,
         };
-        PubDummy {
-            inner: res,
-            _p: PhantomData,
-            _p2: PhantomData,
-        }
+        PubDummy::new(res)
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,4 +1,5 @@
 pub mod operations;
+mod trivial;
 
 use std::{marker::PhantomData, ops::Deref, rc::Rc};
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,11 +1,10 @@
 pub mod operations;
+pub mod optional;
 mod trivial;
 
 use std::{marker::PhantomData, ops::Deref, rc::Rc};
 
-use operations::{
-    Add, And, AsFloat, Assume, Eq, Glob, IsNotNull, Like, Lt, Not, NullIf, Or, UnwrapOr,
-};
+use operations::{Add, And, AsFloat, Eq, Glob, IsNotNull, Like, Lt, Not, Or, UnwrapOr};
 use ref_cast::RefCast;
 use sea_query::{Alias, Expr, Nullable, SelectStatement, SimpleExpr};
 
@@ -13,10 +12,9 @@ use crate::{
     alias::{Field, MyAlias, RawAlias},
     ast::{MySelect, Source},
     db::{TableRow, TableRowInner},
-    dummy::{Cached, Cacher, Prepared, PubDummy, Row},
     hash,
     migrate::NoTable,
-    Dummy, Table,
+    Table,
 };
 
 #[derive(Clone, Copy)]
@@ -175,106 +173,6 @@ impl<'t, S, Typ: 'static> Column<'t, S, Option<Typ>> {
     /// Check that the column is [Some].
     pub fn is_some(&self) -> Column<'t, S, bool> {
         Column::new(IsNotNull(self.inner.clone()))
-    }
-}
-
-pub fn optional<'outer, S, R>(
-    f: impl for<'inner> FnOnce(&mut Optional<'outer, 'inner, S>) -> R,
-) -> R {
-    let mut optional = Optional {
-        nulls: Vec::new(),
-        _p: PhantomData,
-        _p2: PhantomData,
-    };
-    f(&mut optional)
-}
-
-pub struct Optional<'outer, 'inner, S> {
-    nulls: Vec<DynTyped<bool>>,
-    _p: PhantomData<&'inner &'outer ()>,
-    _p2: PhantomData<S>,
-}
-
-impl<'outer, 'inner, S> Optional<'outer, 'inner, S> {
-    /// This method exists for now because `Column` is currently invariant in its lifetime
-    pub fn lower<T: 'static>(
-        &self,
-        col: impl IntoColumn<'outer, S, Typ = T>,
-    ) -> Column<'inner, S, T> {
-        Column::new(col.into_column().inner)
-    }
-
-    /// Could be renamed to `join`
-    pub fn and<T: 'static>(
-        &mut self,
-        col: impl IntoColumn<'inner, S, Typ = Option<T>>,
-    ) -> Column<'inner, S, T> {
-        let column = col.into_column();
-        self.nulls.push(column.is_some().not().into_column().inner);
-        Column::new(Assume(column.inner))
-    }
-
-    /// Could be renamed `map`
-    pub fn then<T: MyTyp<Sql: Nullable> + 'outer>(
-        &self,
-        col: impl IntoColumn<'inner, S, Typ = T>,
-    ) -> Column<'outer, S, Option<T>> {
-        let res = Column::new(Some(col.into_column().inner));
-        self.nulls
-            .iter()
-            .rfold(res, |accum, e| Column::new(NullIf(e.clone(), accum.inner)))
-    }
-
-    pub fn is_some(&self) -> Column<'outer, S, bool> {
-        let any_null = self
-            .nulls
-            .iter()
-            .cloned()
-            .reduce(|a, b| DynTyped(Rc::new(Or(a, b))));
-        // TODO: make this not double wrap the `DynTyped`
-        any_null.map_or(Column::new(true), |x| Column::new(x).not())
-    }
-
-    pub fn then_dummy<'transaction, P>(
-        &self,
-        d: impl Dummy<'inner, 'transaction, S, Prepared<'static> = P>,
-    ) -> PubDummy<'outer, S, OptionalPrepared<P>> {
-        let d = PubDummy::new(d);
-        let mut cacher = Cacher {
-            _p: PhantomData,
-            _p2: PhantomData,
-            columns: d.columns,
-        };
-        let is_some = cacher.cache(self.is_some());
-        PubDummy {
-            columns: cacher.columns,
-            inner: OptionalPrepared {
-                inner: d.inner,
-                is_some,
-            },
-            _p: PhantomData,
-            _p2: PhantomData,
-        }
-    }
-}
-
-pub struct OptionalPrepared<X> {
-    inner: X,
-    is_some: Cached<'static, bool>,
-}
-
-impl<'transaction, X> Prepared<'static, 'transaction> for OptionalPrepared<X>
-where
-    X: Prepared<'static, 'transaction>,
-{
-    type Out = Option<X::Out>;
-
-    fn call(&mut self, row: Row<'_, 'static, 'transaction>) -> Self::Out {
-        if row.get(self.is_some) {
-            Some(self.inner.call(row))
-        } else {
-            None
-        }
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -127,15 +127,6 @@ pub trait IntoColumn<'t, S>: Private + Clone {
     fn into_column(self) -> Column<'t, S, Self::Typ>;
 }
 
-impl<'t, S, T> Column<'t, S, T> {
-    pub fn trivial<'x, X: FromColumn<'x, S, From = T>>(&self) -> Trivial<'t, S, T, X> {
-        Trivial {
-            col: self.clone(),
-            _p: PhantomData,
-        }
-    }
-}
-
 impl<'t, S, T: NumTyp> Column<'t, S, T> {
     /// Add two columns together.
     pub fn add(&self, rhs: impl IntoColumn<'t, S, Typ = T>) -> Column<'t, S, T> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -7,13 +7,11 @@ use std::{marker::PhantomData, ops::Deref, rc::Rc};
 use operations::{Add, And, AsFloat, Eq, Glob, IsNotNull, Like, Lt, Not, Or, UnwrapOr};
 use ref_cast::RefCast;
 use sea_query::{Alias, Expr, Nullable, SelectStatement, SimpleExpr};
-use trivial::Trivial;
 
 use crate::{
     alias::{Field, MyAlias, RawAlias},
     ast::{MySelect, Source},
     db::{TableRow, TableRowInner},
-    dummy::FromColumn,
     hash,
     migrate::NoTable,
     Table,

--- a/src/value.rs
+++ b/src/value.rs
@@ -12,7 +12,7 @@ use crate::{
     alias::{Field, MyAlias, RawAlias},
     ast::{MySelect, Source},
     db::{TableRow, TableRowInner},
-    dummy::{Cacher, DynDummy, PubDummy, Wrapped},
+    dummy::{Cacher, DynDummy, Prepared, PubDummy, Wrapped},
     hash,
     migrate::NoTable,
     Dummy, Table,
@@ -247,9 +247,9 @@ impl<'outer, 'inner, S> Optional<'outer, 'inner, S> {
         let is_some = cacher.cache(self.is_some());
         let res = DynDummy {
             columns: cacher.columns,
-            func: Box::new(move |row| {
+            func: Prepared::new(move |row| {
                 Wrapped::new(if row.get(is_some) {
-                    Some((d.func)(row).0)
+                    Some(d.func.call(row).0)
                 } else {
                     None
                 })

--- a/src/value.rs
+++ b/src/value.rs
@@ -12,7 +12,7 @@ use crate::{
     alias::{Field, MyAlias, RawAlias},
     ast::{MySelect, Source},
     db::{TableRow, TableRowInner},
-    dummy::{Cacher, DynDummy, Prepared, PubDummy, Wrapped},
+    dummy::{Cacher, DynDummy, Prepared, PubDummy},
     hash,
     migrate::NoTable,
     Dummy, Table,
@@ -248,11 +248,11 @@ impl<'outer, 'inner, S> Optional<'outer, 'inner, S> {
         let res = DynDummy {
             columns: cacher.columns,
             func: Prepared::new(move |row| {
-                Wrapped::new(if row.get(is_some) {
-                    Some(d.func.call(row).0)
+                if row.get(is_some) {
+                    Some(d.func.call(row))
                 } else {
                     None
-                })
+                }
             }),
         };
         PubDummy {

--- a/src/value.rs
+++ b/src/value.rs
@@ -128,7 +128,7 @@ pub trait IntoColumn<'t, S>: Private + Clone {
 }
 
 impl<'t, S, T> Column<'t, S, T> {
-    pub fn trivial<'x, X: FromDummy<'x, From = T>>(&self) -> Trivial<'t, S, T, X> {
+    pub fn trivial<'x, X: FromDummy<'x, S, From = T>>(&self) -> Trivial<'t, S, T, X> {
         Trivial {
             col: self.clone(),
             _p: PhantomData,

--- a/src/value/optional.rs
+++ b/src/value/optional.rs
@@ -1,0 +1,113 @@
+use std::{marker::PhantomData, rc::Rc};
+
+use sea_query::Nullable;
+
+use crate::{
+    dummy::{Cached, Cacher, Prepared, PubDummy, Row},
+    Dummy,
+};
+
+use super::{
+    operations::{Assume, NullIf, Or},
+    Column, DynTyped, IntoColumn, MyTyp,
+};
+
+pub fn optional<'outer, S, R>(
+    f: impl for<'inner> FnOnce(&mut Optional<'outer, 'inner, S>) -> R,
+) -> R {
+    let mut optional = Optional {
+        nulls: Vec::new(),
+        _p: PhantomData,
+        _p2: PhantomData,
+    };
+    f(&mut optional)
+}
+
+pub struct Optional<'outer, 'inner, S> {
+    nulls: Vec<DynTyped<bool>>,
+    _p: PhantomData<&'inner &'outer ()>,
+    _p2: PhantomData<S>,
+}
+
+impl<'outer, 'inner, S> Optional<'outer, 'inner, S> {
+    /// This method exists for now because `Column` is currently invariant in its lifetime
+    pub fn lower<T: 'static>(
+        &self,
+        col: impl IntoColumn<'outer, S, Typ = T>,
+    ) -> Column<'inner, S, T> {
+        Column::new(col.into_column().inner)
+    }
+
+    /// Could be renamed to `join`
+    pub fn and<T: 'static>(
+        &mut self,
+        col: impl IntoColumn<'inner, S, Typ = Option<T>>,
+    ) -> Column<'inner, S, T> {
+        let column = col.into_column();
+        self.nulls.push(column.is_some().not().into_column().inner);
+        Column::new(Assume(column.inner))
+    }
+
+    /// Could be renamed `map`
+    pub fn then<T: MyTyp<Sql: Nullable> + 'outer>(
+        &self,
+        col: impl IntoColumn<'inner, S, Typ = T>,
+    ) -> Column<'outer, S, Option<T>> {
+        let res = Column::new(Some(col.into_column().inner));
+        self.nulls
+            .iter()
+            .rfold(res, |accum, e| Column::new(NullIf(e.clone(), accum.inner)))
+    }
+
+    pub fn is_some(&self) -> Column<'outer, S, bool> {
+        let any_null = self
+            .nulls
+            .iter()
+            .cloned()
+            .reduce(|a, b| DynTyped(Rc::new(Or(a, b))));
+        // TODO: make this not double wrap the `DynTyped`
+        any_null.map_or(Column::new(true), |x| Column::new(x).not())
+    }
+
+    pub fn then_dummy<'transaction, P>(
+        &self,
+        d: impl Dummy<'inner, 'transaction, S, Prepared<'static> = P>,
+    ) -> PubDummy<'outer, S, OptionalPrepared<P>> {
+        let d = PubDummy::new(d);
+        let mut cacher = Cacher {
+            _p: PhantomData,
+            _p2: PhantomData,
+            columns: d.columns,
+        };
+        let is_some = cacher.cache(self.is_some());
+        PubDummy {
+            columns: cacher.columns,
+            inner: OptionalPrepared {
+                inner: d.inner,
+                is_some,
+            },
+            _p: PhantomData,
+            _p2: PhantomData,
+        }
+    }
+}
+
+pub struct OptionalPrepared<X> {
+    inner: X,
+    is_some: Cached<'static, bool>,
+}
+
+impl<'transaction, X> Prepared<'static, 'transaction> for OptionalPrepared<X>
+where
+    X: Prepared<'static, 'transaction>,
+{
+    type Out = Option<X::Out>;
+
+    fn call(&mut self, row: Row<'_, 'static, 'transaction>) -> Self::Out {
+        if row.get(self.is_some) {
+            Some(self.inner.call(row))
+        } else {
+            None
+        }
+    }
+}

--- a/src/value/trivial.rs
+++ b/src/value/trivial.rs
@@ -4,9 +4,9 @@ use crate::{dummy::FromDummy, Dummy};
 
 use super::Column;
 
-pub struct Trivial<'t, S, T, X> {
-    col: Column<'t, S, T>,
-    _p: PhantomData<X>,
+pub struct Trivial<'columns, S, T, X> {
+    pub(crate) col: Column<'columns, S, T>,
+    pub(crate) _p: PhantomData<X>,
 }
 
 impl<'transaction, 'columns, S, T, X> Dummy<'columns, 'transaction, S>

--- a/src/value/trivial.rs
+++ b/src/value/trivial.rs
@@ -1,8 +1,11 @@
 use std::marker::PhantomData;
 
-use crate::{dummy::FromDummy, Dummy};
+use crate::{
+    dummy::{Cached, DynDummy, FromDummy},
+    optional, Dummy,
+};
 
-use super::Column;
+use super::{optional::OptionalPrepared, Column};
 
 pub struct Trivial<'columns, S, T, X> {
     pub(crate) col: Column<'columns, S, T>,
@@ -12,7 +15,7 @@ pub struct Trivial<'columns, S, T, X> {
 impl<'transaction, 'columns, S, T, X> Dummy<'columns, 'transaction, S>
     for Trivial<'columns, S, T, X>
 where
-    X: FromDummy<'transaction, From = T>,
+    X: FromDummy<'transaction, S, From = T>,
 {
     type Out = X;
 
@@ -20,5 +23,48 @@ where
 
     fn prepare<'i>(self, cacher: &mut crate::dummy::Cacher<'columns, 'i, S>) -> Self::Prepared<'i> {
         X::prepare(self.col, cacher)
+    }
+}
+
+impl<S> FromDummy<'_, S> for String {
+    type From = String;
+    type Prepared<'i> = Cached<'i, String>;
+
+    fn prepare<'i, 'columns>(
+        col: Column<'columns, S, Self::From>,
+        cacher: &mut crate::dummy::Cacher<'columns, 'i, S>,
+    ) -> Self::Prepared<'i> {
+        cacher.cache(col)
+    }
+}
+
+impl<S> FromDummy<'_, S> for i64 {
+    type From = i64;
+    type Prepared<'i> = Cached<'i, i64>;
+
+    fn prepare<'i, 'columns>(
+        col: Column<'columns, S, Self::From>,
+        cacher: &mut crate::dummy::Cacher<'columns, 'i, S>,
+    ) -> Self::Prepared<'i> {
+        cacher.cache(col)
+    }
+}
+
+impl<'transaction, S, T> FromDummy<'transaction, S> for Option<T>
+where
+    T: FromDummy<'transaction, S>,
+{
+    type From = Option<T::From>;
+    type Prepared<'i> = DynDummy<'i, OptionalPrepared<T::Prepared<'static>>>;
+
+    fn prepare<'i, 'columns>(
+        col: Column<'columns, S, Self::From>,
+        cacher: &mut crate::dummy::Cacher<'columns, 'i, S>,
+    ) -> Self::Prepared<'i> {
+        optional(|row| {
+            let col = row.lower(col);
+            let col = row.and(col);
+            row.then_dummy(col.trivial::<T>()).prepare(cacher)
+        })
     }
 }

--- a/src/value/trivial.rs
+++ b/src/value/trivial.rs
@@ -1,0 +1,24 @@
+use std::marker::PhantomData;
+
+use crate::{dummy::FromDummy, Dummy};
+
+use super::Column;
+
+pub struct Trivial<'t, S, T, X> {
+    col: Column<'t, S, T>,
+    _p: PhantomData<X>,
+}
+
+impl<'transaction, 'columns, S, T, X> Dummy<'columns, 'transaction, S>
+    for Trivial<'columns, S, T, X>
+where
+    X: FromDummy<'transaction, From = T>,
+{
+    type Out = X;
+
+    type Prepared<'i> = X::Prepared<'i>;
+
+    fn prepare<'i>(self, cacher: &mut crate::dummy::Cacher<'columns, 'i, S>) -> Self::Prepared<'i> {
+        X::prepare(self.col, cacher)
+    }
+}

--- a/src/value/trivial.rs
+++ b/src/value/trivial.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::{
-    dummy::{Cached, DynDummy, FromDummy},
+    dummy::{Cached, DynDummy, FromColumn},
     optional, Dummy,
 };
 
@@ -15,7 +15,7 @@ pub struct Trivial<'columns, S, T, X> {
 impl<'transaction, 'columns, S, T, X> Dummy<'columns, 'transaction, S>
     for Trivial<'columns, S, T, X>
 where
-    X: FromDummy<'transaction, S, From = T>,
+    X: FromColumn<'transaction, S, From = T>,
 {
     type Out = X;
 
@@ -26,7 +26,7 @@ where
     }
 }
 
-impl<S> FromDummy<'_, S> for String {
+impl<S> FromColumn<'_, S> for String {
     type From = String;
     type Prepared<'i> = Cached<'i, String>;
 
@@ -38,7 +38,7 @@ impl<S> FromDummy<'_, S> for String {
     }
 }
 
-impl<S> FromDummy<'_, S> for i64 {
+impl<S> FromColumn<'_, S> for i64 {
     type From = i64;
     type Prepared<'i> = Cached<'i, i64>;
 
@@ -50,9 +50,9 @@ impl<S> FromDummy<'_, S> for i64 {
     }
 }
 
-impl<'transaction, S, T> FromDummy<'transaction, S> for Option<T>
+impl<'transaction, S, T> FromColumn<'transaction, S> for Option<T>
 where
-    T: FromDummy<'transaction, S>,
+    T: FromColumn<'transaction, S>,
 {
     type From = Option<T::From>;
     type Prepared<'i> = DynDummy<'i, OptionalPrepared<T::Prepared<'static>>>;

--- a/src/writable.rs
+++ b/src/writable.rs
@@ -11,7 +11,7 @@ pub trait Writable<'t> {
     type Conflict;
     fn get_conflict_unchecked(
         &self,
-    ) -> impl Dummy<'t, 't, 't, Self::Schema, Out = Option<Self::Conflict>>;
+    ) -> impl Dummy<'t, 't, Self::Schema, Out = Option<Self::Conflict>>;
 }
 
 impl<'t, X: Writable<'t>> Writable<'t> for &X {
@@ -26,7 +26,7 @@ impl<'t, X: Writable<'t>> Writable<'t> for &X {
 
     fn get_conflict_unchecked(
         &self,
-    ) -> impl Dummy<'t, 't, 't, Self::Schema, Out = Option<Self::Conflict>> {
+    ) -> impl Dummy<'t, 't, Self::Schema, Out = Option<Self::Conflict>> {
         X::get_conflict_unchecked(self)
     }
 }

--- a/src/writable.rs
+++ b/src/writable.rs
@@ -1,6 +1,11 @@
 use std::marker::PhantomData;
 
-use crate::{alias::Field, ast::MySelect, value::Typed, Dummy, IntoColumn, Table};
+use crate::{
+    alias::Field,
+    ast::MySelect,
+    value::{DynTypedExpr, Typed},
+    Dummy, IntoColumn, Table,
+};
 
 /// this trait is not safe to implement
 pub trait Writable<'t> {
@@ -42,6 +47,12 @@ impl<'t, S> Reader<'_, 't, S> {
         let field = Field::Str(name);
         let val = val.into_column().inner;
         let expr = val.build_expr(self.ast.builder());
+        self.ast.select.push(Box::new((expr, field)))
+    }
+
+    pub(crate) fn col_erased(&self, name: &'static str, val: DynTypedExpr) {
+        let field = Field::Str(name);
+        let expr = (val.0)(self.ast.builder());
         self.ast.select.push(Box::new((expr, field)))
     }
 }

--- a/src/writable.rs
+++ b/src/writable.rs
@@ -11,7 +11,7 @@ pub trait Writable<'t> {
     type Conflict;
     fn get_conflict_unchecked(
         &self,
-    ) -> impl Dummy<'t, 't, Self::Schema, Out = Option<Self::Conflict>>;
+    ) -> impl Dummy<'t, 't, 't, Self::Schema, Out = Option<Self::Conflict>>;
 }
 
 impl<'t, X: Writable<'t>> Writable<'t> for &X {
@@ -26,7 +26,7 @@ impl<'t, X: Writable<'t>> Writable<'t> for &X {
 
     fn get_conflict_unchecked(
         &self,
-    ) -> impl Dummy<'t, 't, Self::Schema, Out = Option<Self::Conflict>> {
+    ) -> impl Dummy<'t, 't, 't, Self::Schema, Out = Option<Self::Conflict>> {
         X::get_conflict_unchecked(self)
     }
 }

--- a/tests/tpc_c.rs
+++ b/tests/tpc_c.rs
@@ -125,8 +125,8 @@ pub fn new_order<'a>(
     let district = txn.query_one(input.customer.district());
 
     #[derive(FromDummy)]
-    // TODO: make this work
-    // #[trivial(District)]
+    #[trivial(District)]
+    #[transaction('t)]
     struct DistrictInfo<'t> {
         warehouse: TableRow<'t, Warehouse>,
         number: i64,
@@ -134,12 +134,7 @@ pub fn new_order<'a>(
         next_order: i64,
     }
 
-    let district_info = txn.query_one(DistrictInfoDummy {
-        warehouse: district.warehouse(),
-        number: district.number(),
-        tax: district.tax(),
-        next_order: district.next_order(),
-    });
+    let district_info: DistrictInfo = txn.query_one(district.trivial());
 
     let warehouse_tax = txn.query_one(district.warehouse().tax());
 


### PR DESCRIPTION
This finally allows returning dummies from `optional` queries
Does not really resolve https://github.com/LHolten/rust-query/issues/20, but this is the (more powerful) replacement.