### PR TITLE
More TPC-C improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ r2d2_sqlite = "0.31.0"
 r2d2 = "0.8"
 static_assertions = "1.1.0"
 self_cell = "1.2.0"
+parking_lot = "0.12.4"
 
 [dev-dependencies]
 trybuild = "1.0.97"

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -4,7 +4,7 @@ use std::{
     marker::PhantomData,
     ops::{Deref, Not},
     path::Path,
-    sync::{Mutex, atomic::AtomicI64},
+    sync::atomic::AtomicI64,
 };
 
 use rusqlite::{Connection, config::DbConfig};
@@ -547,7 +547,7 @@ impl<S: Schema> Migrator<S> {
             manager: self.manager,
             schema_version: AtomicI64::new(schema_version),
             schema: PhantomData,
-            mut_lock: Mutex::new(()),
+            mut_lock: parking_lot::FairMutex::new(()),
         })
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -122,38 +122,44 @@ impl<S: Send + Sync + Schema> Database<S> {
         &self,
         f: impl Send + FnOnce(&'static mut Transaction<S>) -> Result<O, E>,
     ) -> Result<O, E> {
-        let _guard = self.mut_lock.lock();
-        let res = std::thread::scope(|scope| {
+        use r2d2::ManageConnection;
+        let conn = self.manager.connect().unwrap();
+
+        // Acquire the lock just before creating the transaction
+        let guard = self.mut_lock.lock();
+
+        let owned = OwnedTransaction::new(MutBorrow::new(conn), |conn| {
+            let txn = conn
+                .borrow_mut()
+                .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+                .unwrap();
+            Some(txn)
+        });
+        let join_res = std::thread::scope(|scope| {
             scope
                 .spawn(|| {
-                    use r2d2::ManageConnection;
-
-                    let conn = self.manager.connect().unwrap();
-                    let owned = OwnedTransaction::new(MutBorrow::new(conn), |conn| {
-                        let txn = conn
-                            .borrow_mut()
-                            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
-                            .unwrap();
-                        Some(txn)
-                    });
-
                     let res = f(Transaction::new_checked(owned, &self.schema_version));
-
                     let owned = TXN.take().unwrap();
-
-                    if res.is_ok() {
-                        owned.with(|x| x.commit().unwrap());
-                    } else {
-                        owned.with(|x| x.rollback().unwrap());
-                    }
-                    res
+                    (res, owned)
                 })
                 .join()
         });
-        match res {
+
+        // Drop the guard before commiting to let sqlite go to the next transaction
+        // more quickly while guaranteeing that the database will unlock soon.
+        drop(guard);
+
+        let (res, owned) = match join_res {
             Ok(val) => val,
             Err(payload) => std::panic::resume_unwind(payload),
+        };
+
+        if res.is_ok() {
+            owned.with(|x| x.commit().unwrap());
+        } else {
+            owned.with(|x| x.rollback().unwrap());
         }
+        res
     }
 
     /// Same as [Self::transaction_mut], but always commits the transaction.

--- a/tests/tpc_c/emulated_user.rs
+++ b/tests/tpc_c/emulated_user.rs
@@ -113,12 +113,12 @@ impl Emulate {
                     stats.add_individual_time(|| payment::payment(txn, input))
                 }));
             }
-            TxnKind::OrderStatus => db.transaction(|txn| {
-                let warehouse = get_warehouse(txn);
-                black_box(
-                    stats.add_individual_time(|| order_status::random_order_status(txn, warehouse)),
-                );
-            }),
+            TxnKind::OrderStatus => {
+                let input = order_status::generate_input(self.warehouse);
+                black_box(db.transaction(|txn| {
+                    stats.add_individual_time(|| order_status::order_status(txn, input))
+                }));
+            }
             TxnKind::Delivery => {
                 let input = delivery::generate_input(self.warehouse);
                 for district_num in 1..=10 {

--- a/tests/tpc_c/emulated_user.rs
+++ b/tests/tpc_c/emulated_user.rs
@@ -102,18 +102,10 @@ impl Emulate {
         let before = Instant::now();
         match txn_kind {
             TxnKind::NewOrder => {
-                let _ = db.transaction_mut(|txn| {
-                    stats
-                        .add_individual_time(|| {
-                            new_order::random_new_order(txn, self.warehouse, &self.other_warehouses)
-                        })
-                        .map(|val| {
-                            black_box(val);
-                        })
-                        .map_err(|val| {
-                            black_box(val);
-                        })
-                });
+                let input = new_order::generate_input(self.warehouse, &self.other_warehouses);
+                let _ = black_box(db.transaction_mut(|txn| {
+                    stats.add_individual_time(|| new_order::new_order(txn, input))
+                }));
             }
             TxnKind::Payment => db.transaction_mut_ok(|txn| {
                 black_box(stats.add_individual_time(|| {

--- a/tests/tpc_c/emulated_user.rs
+++ b/tests/tpc_c/emulated_user.rs
@@ -107,11 +107,12 @@ impl Emulate {
                     stats.add_individual_time(|| new_order::new_order(txn, input))
                 }));
             }
-            TxnKind::Payment => db.transaction_mut_ok(|txn| {
-                black_box(stats.add_individual_time(|| {
-                    payment::random_payment(txn, self.warehouse, &self.other_warehouses)
+            TxnKind::Payment => {
+                let input = payment::generate_input(self.warehouse, &self.other_warehouses);
+                black_box(db.transaction_mut_ok(|txn| {
+                    stats.add_individual_time(|| payment::payment(txn, input))
                 }));
-            }),
+            }
             TxnKind::OrderStatus => db.transaction(|txn| {
                 let warehouse = get_warehouse(txn);
                 black_box(

--- a/tests/tpc_c/expect.rs
+++ b/tests/tpc_c/expect.rs
@@ -2,14 +2,14 @@ pub fn collect_all<R>(f: impl FnMut() -> R) -> R {
     let (res, plans) = rust_query::private::get_plan(f);
 
     for (sql, plan) in plans {
-        assert!(sql.starts_with("INSERT INTO"));
-
-        expect_test::expect![[r#"
+        if sql.starts_with("INSERT INTO") {
+            expect_test::expect![[r#"
             QUERY PLAN [
                 SCAN CONSTANT ROW,
             ]
         "#]]
-        .assert_debug_eq(&plan);
+            .assert_debug_eq(&plan);
+        }
     }
 
     res

--- a/tests/tpc_c/main.rs
+++ b/tests/tpc_c/main.rs
@@ -142,7 +142,7 @@ pub mod vN {
 }
 use v0::*;
 
-use crate::emulated_user::{Emulate, print_stats, stop_emulation};
+use crate::emulated_user::{Emulate, EmutateWithQueue, print_stats, stop_emulation};
 
 const DB_FILE: &'static str = "tpc.sqlite";
 const INIT: bool = true;
@@ -176,10 +176,13 @@ fn main() {
         for district in 1..=10 {
             let db = db.clone();
             threads.push(thread::spawn(move || {
-                Emulate {
-                    db,
-                    warehouse,
-                    district,
+                EmutateWithQueue {
+                    info: Arc::new(Emulate {
+                        db,
+                        warehouse,
+                        district,
+                        other_warehouses: (1..=WAREHOUSE_CNT).filter(|x| x != &warehouse).collect(),
+                    }),
                     queue: vec![],
                 }
                 .loop_emulate();

--- a/tests/tpc_c/main.rs
+++ b/tests/tpc_c/main.rs
@@ -1,3 +1,10 @@
+//! You can run this benchmark as `cargo test --release --test tpc_c`.
+//! It will run with increasingly more warehouses and users.
+//! The benchmark stops when any of the transaction types has more than 10% late.
+//! At that point you can read the previous number of `new_order` transactions executed
+//! divided by the number of minutes (default 2) as the approximate tpmC.
+//! Note that for a real measurement the performance needs to be measured for several hours.
+
 use std::{
     env::args,
     ops::RangeInclusive,
@@ -154,7 +161,7 @@ fn main() {
         .skip(1)
         .next()
         .map(|x| x.parse().unwrap())
-        .unwrap_or(10);
+        .unwrap_or(50);
 
     let mut config = Config::open(DB_FILE);
     config.foreign_keys = rust_query::migration::ForeignKeys::Rust;
@@ -203,7 +210,7 @@ fn test_cnt(db: Arc<Database<Schema>>, warehouse_cnt: i64) -> bool {
         }
     }
 
-    thread::sleep(Duration::from_secs(60));
+    thread::sleep(Duration::from_secs(120));
 
     println!("benchmark complete");
     stop_emulation();

--- a/tests/tpc_c/payment.rs
+++ b/tests/tpc_c/payment.rs
@@ -24,7 +24,7 @@ pub fn generate_input(warehouse: i64, other: &[i64]) -> PaymentInput {
     }
 }
 
-struct PaymentInput {
+pub struct PaymentInput {
     warehouse: i64,
     district: i64,
     customer: CustomerIdent,

--- a/tests/tpc_c/stock_level.rs
+++ b/tests/tpc_c/stock_level.rs
@@ -1,30 +1,27 @@
 use super::*;
-use rust_query::{TableRow, Transaction, aggregate};
+use rust_query::{Transaction, aggregate};
 
-pub fn random_stock_level(txn: &Transaction<Schema>, district: TableRow<District>) -> i64 {
-    let input = generate_input(district);
-    stock_level(txn, input)
-}
-
-// returns the minimum quantity
-fn generate_input(district: TableRow<District>) -> StockLevelInput {
+pub fn generate_input(warehouse: i64, district: i64) -> StockLevelInput {
     StockLevelInput {
+        warehouse,
         district,
         minimum_quantity: rand::random_range(10..=20),
     }
 }
 
-struct StockLevelInput {
-    district: TableRow<District>,
+pub struct StockLevelInput {
+    warehouse: i64,
+    district: i64,
     minimum_quantity: i64,
 }
 
-fn stock_level(txn: &Transaction<Schema>, input: StockLevelInput) -> i64 {
-    let district = input.district.into_expr();
-
+pub fn stock_level(txn: &Transaction<Schema>, input: StockLevelInput) -> i64 {
     txn.query_one(aggregate(|rows| {
         let ol = rows.join(OrderLine);
-        rows.filter(ol.order.customer.district.eq(&district));
+        let district = &ol.order.customer.district;
+        rows.filter(district.warehouse.number.eq(input.warehouse));
+        rows.filter(district.number.eq(input.district));
+
         rows.filter(ol.number.gte(district.next_order.sub(20)));
         rows.filter(ol.stock.quantity.lt(input.minimum_quantity));
         rows.count_distinct(&ol.stock)


### PR DESCRIPTION
Several changes:
- Updated the transactions to use less queries.
- Changed inputs and outputs to not contain `TableRow`.
- Fixed set of other warehouses in `new_order` and `payment`.
- Automatically test multiple database sizes.
- Switched mutable transaction to use `parking_lot::FairMutex`
- Allowed parallel mutable transactions in commit phase.
This has increased the tpmC by ~1.8x (it is now ~1660 on my laptop).